### PR TITLE
Update Versions and Add JQ

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         base-image: ["alpine", "ubuntu"]
         # Two latest versions, previous two latest minor versions, and previous latest major version
-        version: ["2.14.3", "2.14.2", "2.13.0", "2.12.1", "1.14.0"]
+        version: ["2.23.0", "2.22.1", "2.22.0", "1.14.0"]
     env:
       LATEST_VERSION: "2.14.3"
       REGISTRY: ghcr.io

--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,6 @@
 # Unofficial GitHub CLI Docker Image
 
 ![GitHub issues](https://img.shields.io/github/issues-raw/jackm25/docker-github-cli)
-![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/Jackm25/docker-github-cli/Build%20and%20Publish/main)
 
 Unofficial GitHub CLI Docker Image, containing the GitHub CLI tool and other related tools.
 

--- a/README.MD
+++ b/README.MD
@@ -19,6 +19,7 @@ However, in addition to `gh`, the image also includes:
 *  `gzip`
 *  `tar`
 *  `wget`
+*  `jq`
 
 ## Image Variants
 
@@ -106,4 +107,4 @@ cd alpine # or cd ubuntu for the ubuntu based image
 ```
 
 ## License
-Licensed under the MIT Licence
+Licensed under the MIT License

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 ARG GH_CLI_VERSION
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -10,6 +10,6 @@ RUN wget https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH
         rm -r /gh_${GH_CLI_VERSION}_linux_amd64
 
 # CURL
-RUN apk add curl
+RUN apk add curl jq
 
 CMD ["gh"]

--- a/alpine/test-image.sh
+++ b/alpine/test-image.sh
@@ -41,6 +41,7 @@ test_program_exists "cURL" "curl --version"
 test_program_exists "Gzip" "which gzip"
 test_program_exists "tar" "tar --version"
 test_program_exists "wget" "which wget"
+test_program_exists "jq" "which jq"
 
 # Check the image is indeed built on Ubuntu
 echo "Checking container is build on Alpine..."

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 ARG GH_CLI_VERSION
 
 # CURL and WGET
-RUN apt-get update && apt-get install -y curl wget
+RUN apt-get update && apt-get install -y curl wget jq
 
 # GitHub CLI
 RUN wget https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_amd64.tar.gz && \

--- a/ubuntu/test-image.sh
+++ b/ubuntu/test-image.sh
@@ -41,6 +41,7 @@ test_program_exists "cURL" "curl --version"
 test_program_exists "Gzip" "gzip --version"
 test_program_exists "tar" "tar --version"
 test_program_exists "wget" "wget --version"
+test_program_exists "jq" "jq --version"
 
 # Check the image is indeed built on Ubuntu
 echo "Checking container is build on Ubuntu..."


### PR DESCRIPTION
Updated the following versions:

- GitHub CLI to now build on versions `2.23.0`, `2.22.1`, `2.22.0` and `1.14.0`
- Alpine to now use `3.17` as the base image

Also added `jq` to the images, for working with JSON data.