### PR TITLE
Fix Issue with latest Tag

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -21,7 +21,7 @@ jobs:
         # Two latest versions, previous two latest minor versions, and previous latest major version
         version: ["2.23.0", "2.22.1", "2.22.0", "1.14.0"]
     env:
-      LATEST_VERSION: "2.14.3"
+      LATEST_VERSION: "2.23.0"
       REGISTRY: ghcr.io
       IMAGE_NAME: jackm25/github-cli
     steps:


### PR DESCRIPTION
Update the `LATEST_VERSION` property to `2.23.0` so that the `latest` tag is set correctly on the docker images.